### PR TITLE
rename mini-swe-webagent to Webwright

### DIFF
--- a/skills/webwright/reference/cli_tool_mode.md
+++ b/skills/webwright/reference/cli_tool_mode.md
@@ -6,7 +6,7 @@ provided. **CLI tool mode** (`/webwright:craft`) instead produces a
 **reusable, parameterized CLI tool**: the same script can be re-run later
 with different argument values to perform the same kind of task.
 
-This mode is adapted from `mini-web-agent/src/webwright/config/crafted_cli.yaml`'s
+This mode is adapted from `webwright/src/webwright/config/crafted_cli.yaml`'s
 "Final-Script Shape (CLI Tool, MANDATORY)" contract. The OpenAI-backed
 `self_reflection` gate is replaced by your own self-verification against
 `plan.md`.

--- a/src/webwright/utils/runtime.py
+++ b/src/webwright/utils/runtime.py
@@ -11,4 +11,4 @@ def run_async(coro) -> T:
         asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(coro)
-    raise RuntimeError("mini-swe-webagent does not support running inside an active event loop.")
+    raise RuntimeError("Webwright does not support running inside an active event loop.")


### PR DESCRIPTION
Addressed two mentions of the previous project name. However, there's still stuff like:

src/webwright/__init__.py
25:    os.getenv("**MSWEBA**_GLOBAL_CONFIG_DIR") or user_config_dir("**mini-swe-webagent**")

src/webwright/agents/default.py
422:                "trajectory_format": "**mini-swe-webagent**-0.1",