### PR TITLE
fix(skill): force utf-8 stdout in playwright_patterns.md to prevent Windows cp1252 crash

### DIFF
--- a/skills/webwright/reference/playwright_patterns.md
+++ b/skills/webwright/reference/playwright_patterns.md
@@ -16,9 +16,16 @@ the first task.
 python - <<'PY'
 import asyncio
 import os
+import sys
 from pathlib import Path
 
 from playwright.async_api import async_playwright
+
+# Windows defaults sys.stdout.encoding to cp1252, which crashes the moment
+# aria_snapshot()/page text contains any non-cp1252 glyph (e.g. arxiv's
+# "▽ More" abstract toggle is U+25BD). Force utf-8 so the skeleton works
+# unchanged across platforms; no-op on POSIX where stdout is already utf-8.
+sys.stdout.reconfigure(encoding="utf-8")
 
 WORKSPACE = Path(os.environ.get("WORKSPACE_DIR", "."))
 SCREENSHOTS = WORKSPACE / "screenshots"
@@ -53,6 +60,12 @@ Rules:
   and final-run screenshots alike.
 - Each Playwright run is fresh: navigate from the start URL, reapply
   filters, reconstruct state in code. There is no persistent session.
+- **Windows note:** keep the `sys.stdout.reconfigure(encoding="utf-8")`
+  line at the top of every heredoc. Without it, the script crashes with
+  `UnicodeEncodeError: 'charmap' codec can't encode character ...` as
+  soon as the page emits a non-cp1252 glyph through `print()`. Setting
+  `PYTHONIOENCODING=utf-8` in the environment is an equivalent
+  alternative.
 
 ## Targeting elements with role + name
 
@@ -127,19 +140,26 @@ Guidelines for the interactive path:
 - print the final datum at the end of the log.
 
 ```python
-import asyncio, os
+import asyncio, os, sys
 from pathlib import Path
 from playwright.async_api import async_playwright
+
+# See the "Windows note" under the Browser launch skeleton above —
+# this line keeps the script working on Windows when log/print output
+# contains non-cp1252 glyphs (typography symbols, emoji, CJK, math).
+# No-op on POSIX where stdout is already utf-8.
+sys.stdout.reconfigure(encoding="utf-8")
 
 RUN_DIR = Path(__file__).parent
 SCREENSHOTS = RUN_DIR / "screenshots"
 SCREENSHOTS.mkdir(parents=True, exist_ok=True)
 LOG = RUN_DIR / "final_script_log.txt"
-LOG.write_text("")  # reset
+LOG.write_text("", encoding="utf-8")  # reset
 
 def log(step: int, msg: str) -> None:
     line = f"step {step} action: {msg}\n"
-    LOG.open("a").write(line)
+    with LOG.open("a", encoding="utf-8") as f:
+        f.write(line)
     print(line, end="")
 
 async def main():


### PR DESCRIPTION
## Summary

Fixes #7 — the canonical Python skeletons in `skills/webwright/reference/playwright_patterns.md` crash with `UnicodeEncodeError` on Windows the moment `aria_snapshot()` (or any other page text passed to `print()`) contains a glyph outside cp1252.

Two real-world cases that already trigger it:

- arxiv search results page — the "▽ More" abstract toggle is `U+25BD`
- Any page with typography symbols, emoji, CJK characters, math symbols, etc.

A Windows user copy-pasting the recommended explore skeleton from the doc hits the crash on the first non-trivial page. See issue #7 for the verbatim repro + traceback.

## Changes

Single file: `skills/webwright/reference/playwright_patterns.md`.

1. **Browser launch skeleton** — add `import sys` and `sys.stdout.reconfigure(encoding=\"utf-8\")` near the top of the heredoc with an inline comment explaining why.
2. **Final-script instrumentation** — same reconfigure at the top, plus pass `encoding=\"utf-8\"` explicitly to `LOG.write_text(...)` and `LOG.open(\"a\", ...)` so non-cp1252 glyphs landing in the log file cannot crash on Windows either.
3. **Rules section** — added a short "Windows note" describing the line and the equivalent `PYTHONIOENCODING=utf-8` environment override.

The reconfigure is a no-op on POSIX where stdout is already utf-8, so the skeletons keep working unchanged on Linux/macOS.

## Verification

Without the fix (verbatim heredoc from the doc, default Windows cp1252 stdout):

```
UnicodeEncodeError: 'charmap' codec can't encode character '▽' in position 4958: character maps to <undefined>
  File ".../Lib/encodings/cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
```

With the fix on the same arxiv search results page:

```
ARIA: <full accessibility tree printed cleanly, U+25BD included>
exit code: 0
```

## Test plan

- [x] Confirmed verbatim heredoc from the pre-fix doc crashes on Windows 11 + Python 3.12 + Playwright Firefox.
- [x] Confirmed the patched skeleton runs clean on the same machine, same page.
- [x] Verified the change is a no-op on POSIX (reconfigure to utf-8 when already utf-8 changes nothing).
- [x] Ran the full Webwright arxiv-search task end-to-end with the patched Final-script skeleton — all critical points verified, no encoding errors in log or stdout.