### PR TITLE
docs: clarify Playwright browser prerequisite for standalone vs skill mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,14 @@ python assets/task_showcase/app.py \
 ### Prerequisites
 
 - Python 3.10+
-- Chromium installed through Playwright
+- Playwright browser installed (Chromium for standalone mode; Firefox when using the Claude Code skill)
 - An API key for your chosen backend (OpenAI, Anthropic, or OpenRouter)
 
 ### Install
 
 ```bash
 pip install -e .
-playwright install chromium
+playwright install chromium  # or: playwright install firefox (for Claude Code skill mode)
 ```
 
 ### Run


### PR DESCRIPTION
### Problem
The README Prerequisites section lists only Chromium, but `SKILL.md` requires Firefox for the Claude Code skill mode. New users following the README and running the skill encounter an error because the wrong browser is installed.

### Fix
Update the prerequisite bullet and the `playwright install` command in the Quick Start section to mention both Chromium (standalone mode) and Firefox (Claude Code skill mode), with a brief note indicating which mode each is for.

### Changes
- **README.md** — prerequisite bullet updated from "Chromium installed through Playwright" to "Playwright browser installed (Chromium for standalone mode; Firefox when using the Claude Code skill)"; install command updated with an inline comment pointing to `playwright install firefox` for skill mode

### Not affected
- `SKILL.md` — already documents `playwright install firefox` correctly; not touched
- All Python source files — not touched

Closes #11