### PR TITLE
docs: add 30-second quick-start callout above Performance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ https://github.com/user-attachments/assets/4ed94cd5-11be-4daa-b2d7-1260a803baca
 
 ---
 
+## ⚡ 30-second start
+
+```bash
+pip install -e .
+playwright install chromium
+export OPENAI_API_KEY=sk-...   # or ANTHROPIC_API_KEY / OPENROUTER_API_KEY
+python -m webwright.run.cli -c base.yaml -c model_openai.yaml \
+  -t "Go to github.com and find the trending repos"
+```
+
+> New here? Jump straight to [Quick Start](#-quick-start) for the full setup guide.
+
+---
+
 ## 📊 Performance
 
 State-of-the-art on two real-website benchmarks with a 100-step budget — see the [blog post](https://www.microsoft.com/en-us/research/articles/webwright-a-terminal-is-all-you-need-for-web-agents/) for full details.


### PR DESCRIPTION
### Problem
Issue #20 notes that new users hit ~160 lines of motivation text, architecture comparisons, and benchmark tables before reaching the Quick Start section. First-time visitors who want to just try the tool have no fast path.

### Fix
Insert a short "⚡ 30-second start" section immediately after the Demo video and before the Performance section. It contains a four-line copy-paste snippet (install, browser, API key, run command) and a link down to the full Quick Start section for users who want the complete guide.

### Changes
- **README.md** — added `## ⚡ 30-second start` block (14 lines) between the Demo and Performance sections; no existing content removed or restructured

### Not affected
- The existing `## 🚀 Quick Start` section — not touched; the callout links to it
- All Python source files — not touched

Closes #20