### PR TITLE
fix: skip bash syntax validation on Windows

### DIFF
--- a/src/webwright/models/base.py
+++ b/src/webwright/models/base.py
@@ -6,6 +6,7 @@ import json
 import mimetypes
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -121,6 +122,8 @@ def parse_json_output(raw: str, *, action_field: str = "bash_command") -> dict[s
 
 
 def _validate_bash_command(command: str) -> None:
+    if sys.platform == "win32":
+        return
     result = subprocess.run(
         ["/bin/bash", "-n"],
         input=command,

--- a/tests/unit/test_bash_validation.py
+++ b/tests/unit/test_bash_validation.py
@@ -1,0 +1,39 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from webwright.models.base import _validate_bash_command
+
+
+def _make_proc(returncode: int, stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stderr = stderr
+    proc.stdout = ""
+    return proc
+
+
+def test_valid_command_passes_on_posix(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with patch("subprocess.run", return_value=_make_proc(0)):
+        _validate_bash_command("echo hello")
+
+
+def test_invalid_syntax_raises_on_posix(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with patch("subprocess.run", return_value=_make_proc(1, "syntax error near unexpected token")):
+        with pytest.raises(ValueError, match="Invalid bash_command syntax"):
+            _validate_bash_command("if then fi done ;;;")
+
+
+def test_validation_skipped_on_windows(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    _validate_bash_command("if then fi done ;;;")
+
+
+def test_validation_skipped_on_windows_does_not_call_subprocess(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    with patch("subprocess.run") as mock_run:
+        _validate_bash_command("echo hi")
+        mock_run.assert_not_called()


### PR DESCRIPTION
### Problem
`_validate_bash_command` in `base.py` calls `/bin/bash -n` to syntax-check each agent action. On Windows, `/bin/bash` does not exist, so `subprocess.run` raises `FileNotFoundError`. This propagates as an unhandled exception on every agent step, preventing Webwright from running on Windows at all.

### Fix
Guard the `subprocess.run` call with `sys.platform == "win32"` and return early. On Windows the command is passed through without syntax validation; on POSIX the existing behavior is preserved exactly.

### Changes
- **`src/webwright/models/base.py`** — added `import sys`; added a `if sys.platform == "win32": return` guard at the top of `_validate_bash_command`
- **`tests/unit/test_bash_validation.py`** — four new tests: valid command on POSIX, invalid syntax raises `ValueError` on POSIX, validation is skipped on Windows, and `subprocess.run` is never called on Windows

### Not affected
- POSIX behavior — unchanged; `/bin/bash -n` is still called and errors still raise `ValueError`
- Any other function in `base.py` — not touched