### PR TITLE
docs: document Gemini and other model support via OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,31 @@ python -m webwright.run.cli \
 | `--task-id` | Output subfolder name. |
 | `-o` | Output directory. |
 
+### Other models via OpenRouter
+
+Any model accessible through [OpenRouter](https://openrouter.ai/) — including Gemini, Mistral, Llama, and others — works by using `model_class: openrouter` and setting `model_name` to the OpenRouter model ID. A ready-to-use config for Gemini is included:
+
+```bash
+export OPENROUTER_API_KEY=<your-key>
+python -m webwright.run.cli \
+    -c base.yaml -c model_gemini_openrouter.yaml \
+    -t "Search for flights from SEA to JFK on 2026-08-15 to 2026-08-20" \
+    --start-url https://www.google.com/flights \
+    --task-id demo_gemini \
+    -o outputs/default
+```
+
+To use a different OpenRouter model, override `model.model_name` inline:
+
+```bash
+python -m webwright.run.cli \
+    -c base.yaml -c model_openrouter.yaml \
+    model.model_name=mistralai/mistral-large \
+    -t "..." -o outputs/default
+```
+
+Available config files in `src/webwright/config/`: `model_openai.yaml`, `model_claude.yaml`, `model_openrouter.yaml`, `model_gemini_openrouter.yaml`.
+
 ---
 
 ## 🔌 Use as a Plugin

--- a/src/webwright/config/model_gemini_openrouter.yaml
+++ b/src/webwright/config/model_gemini_openrouter.yaml
@@ -1,0 +1,12 @@
+# Model modifier — Gemini via OpenRouter.
+#
+# Stack on top of base.yaml or local_browser.yaml:
+#   python -m webwright.run.cli -c base.yaml -c model_gemini_openrouter.yaml ...
+#   python -m webwright.run.cli -c base.yaml -c local_browser.yaml -c model_gemini_openrouter.yaml ...
+#
+# Required env: OPENROUTER_API_KEY.
+
+model:
+  model_class: openrouter
+  model_name: google/gemini-2.0-flash
+  openrouter_endpoint: https://openrouter.ai/api/v1/chat/completions


### PR DESCRIPTION
### Problem
Issue #18 asks whether Gemini models are supported. They are — via OpenRouter — but this is not documented anywhere in the README or config directory. Users have no way to discover this without reading the source.

### Fix
Add a short note to the README explaining that any OpenRouter-accessible model (Gemini, Mistral, Llama, etc.) works by pointing `-c model_openrouter.yaml` and overriding `model.model_name`. Add `model_gemini_openrouter.yaml` as a ready-to-use example config.

### Changes
- **`README.md`** — added a note about OpenRouter model support near the backends section
- **`src/webwright/config/model_gemini_openrouter.yaml`** — example config for `google/gemini-2.0-flash` via OpenRouter

### Not affected
- All Python source files — not touched
- Existing config files — not touched

Closes #18