### PR TITLE
fix: use last_usage_ prefix for usage metrics in get_template_vars

### DIFF
--- a/src/webwright/models/base.py
+++ b/src/webwright/models/base.py
@@ -296,11 +296,11 @@ class BaseModel:
         for k, v in self._last_request_metrics.items():
             vars[f"last_request_{k}"] = v
         for k, v in self._last_usage_metrics.items():
-            vars[f"last_request_{k}"] = v
+            vars[f"last_usage_{k}"] = v
         for k, v in self._cumulative_request_metrics.items():
             vars[f"cumulative_request_{k}"] = v
         for k, v in self._cumulative_usage_metrics.items():
-            vars[f"cumulative_{k}"] = v
+            vars[f"cumulative_usage_{k}"] = v
         vars.update(kwargs)
         return vars
 

--- a/tests/unit/test_get_template_vars.py
+++ b/tests/unit/test_get_template_vars.py
@@ -1,0 +1,54 @@
+"""Tests for get_template_vars metric key naming."""
+
+from webwright.models.base import BaseModel
+
+
+class _ConcreteModel(BaseModel):
+    """Minimal concrete subclass — no API key required."""
+
+    _API_KEY_FIELD = ""
+
+
+def test_last_usage_keys_do_not_overwrite_last_request_keys() -> None:
+    model = _ConcreteModel(action_field="bash_command")
+
+    # Inject distinct values so we can tell them apart.
+    model._last_request_metrics["message_count"] = 3
+    model._last_usage_metrics["input_tokens"] = 100
+
+    result = model.get_template_vars()
+
+    assert "last_request_message_count" in result, (
+        "last_request_message_count missing from get_template_vars output"
+    )
+    assert "last_usage_input_tokens" in result, (
+        "last_usage_input_tokens missing from get_template_vars output"
+    )
+    assert result["last_request_message_count"] == 3
+    assert result["last_usage_input_tokens"] == 100
+
+    # The old bug: usage keys were written as last_request_*, which would
+    # clobber real request keys.  Verify the buggy key is absent.
+    assert "last_request_input_tokens" not in result, (
+        "last_request_input_tokens should not exist; usage metrics must use last_usage_ prefix"
+    )
+
+
+def test_cumulative_usage_keys_use_cumulative_usage_prefix() -> None:
+    model = _ConcreteModel(action_field="bash_command")
+
+    model._cumulative_usage_metrics["input_tokens"] = 500
+    model._cumulative_request_metrics["message_count"] = 7
+
+    result = model.get_template_vars()
+
+    assert "cumulative_usage_input_tokens" in result
+    assert result["cumulative_usage_input_tokens"] == 500
+
+    assert "cumulative_request_message_count" in result
+    assert result["cumulative_request_message_count"] == 7
+
+    # Old bug: cumulative usage used "cumulative_" prefix, which is inconsistent.
+    assert "cumulative_input_tokens" not in result, (
+        "cumulative_input_tokens should not exist; cumulative usage must use cumulative_usage_ prefix"
+    )


### PR DESCRIPTION
### Problem
In `get_template_vars`, both the `_last_request_metrics` and `_last_usage_metrics` loops write keys with the prefix `"last_request_"`. This causes the usage keys (e.g. `last_request_input_tokens`) to silently overwrite the request keys (e.g. `last_request_message_count`) when they share the same suffix. Similarly, `_cumulative_usage_metrics` uses `"cumulative_"` while `_cumulative_request_metrics` uses `"cumulative_request_"` — an inconsistent naming scheme.

### Fix
Change the `_last_usage_metrics` loop prefix to `"last_usage_"` and the `_cumulative_usage_metrics` loop prefix to `"cumulative_usage_"`.

### Changes
- **`src/webwright/models/base.py`** — fixed the two misnamed prefixes in `get_template_vars`
- **`tests/unit/test_get_template_vars.py`** — added tests asserting both `last_request_message_count` and `last_usage_input_tokens` appear as distinct keys, and that cumulative usage uses `cumulative_usage_` prefix

### Not affected
- `_usage_snapshot()` — separate method, not touched
- All other methods in `base.py` — not touched