### PR TITLE
fix: rename MSWEBA_GLOBAL_CONFIG_DIR to WEBWRIGHT_CONFIG_DIR

### DIFF
--- a/src/webwright/__init__.py
+++ b/src/webwright/__init__.py
@@ -22,7 +22,7 @@ __version__ = "0.1.0"
 
 package_dir = Path(__file__).resolve().parent
 global_config_dir = Path(
-    os.getenv("MSWEBA_GLOBAL_CONFIG_DIR") or user_config_dir("webwright")
+    os.getenv("WEBWRIGHT_CONFIG_DIR") or user_config_dir("webwright")
 )
 global_config_dir.mkdir(parents=True, exist_ok=True)
 global_config_file = global_config_dir / ".env"


### PR DESCRIPTION
## Summary
- Env var `MSWEBA_GLOBAL_CONFIG_DIR` renamed to `WEBWRIGHT_CONFIG_DIR` in `src/webwright/__init__.py`
- Migration: if you set `MSWEBA_GLOBAL_CONFIG_DIR` in your shell profile, rename it to `WEBWRIGHT_CONFIG_DIR`

## Why
PR #4 renamed the project from `mini-swe-webagent` to Webwright but left the legacy `MSWEBA_` prefix in the config dir env var. The old name is confusing and inconsistent with the project's current identity.

## Changes
- `src/webwright/__init__.py`: env var lookup updated from `MSWEBA_GLOBAL_CONFIG_DIR` to `WEBWRIGHT_CONFIG_DIR`

## Testing
```
pytest tests/ -v -k "config"
```

```
============================= test session starts =============================
platform win32 -- Python 3.14.3, pytest-7.4.4, pluggy-1.6.0
collected 7 items / 4 deselected / 3 selected

tests/unit/test_tool_model_routing.py::test_resolve_model_config_path_prefers_explicit_arg PASSED
tests/unit/test_tool_model_routing.py::test_resolve_model_config_path_falls_back_to_workspace_snapshot PASSED
tests/unit/test_tool_model_routing.py::test_resolve_model_config_path_raises_when_nothing_found PASSED

3 passed, 4 deselected in 0.11s
```