### PR TITLE
fix: check any provider API key in doctor command

### DIFF
--- a/src/webwright/run/doctor.py
+++ b/src/webwright/run/doctor.py
@@ -75,12 +75,13 @@ def check_screenshot():
         )
 
 
-def check_openai_key():
-    if os.getenv("OPENAI_API_KEY"):
-        return True, "OPENAI_API_KEY found"
-
+def check_api_key():
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"):
+        if os.getenv(var):
+            return True, f"{var} found"
     return False, (
-        "OPENAI_API_KEY missing\nFix: set the OPENAI_API_KEY environment variable"
+        "No API key found\n"
+        "Fix: set OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY"
     )
 
 
@@ -110,7 +111,7 @@ CHECKS = [
     ("Playwright", check_playwright),
     ("Chromium", check_chromium),
     ("Screenshot", check_screenshot),
-    ("OpenAI Key", check_openai_key),
+    ("API Key", check_api_key),
     ("Plugins", check_plugin_manifests),
 ]
 

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 from webwright.run.doctor import (
+    check_api_key,
     check_chromium,
-    check_openai_key,
     check_playwright,
     check_plugin_manifests,
     check_python,
@@ -38,22 +38,51 @@ def test_check_screenshot():
     assert isinstance(message, str)
 
 
-def test_check_openai_key_exists(monkeypatch):
+def test_check_api_key_openai(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
-    ok, message = check_openai_key()
+    ok, message = check_api_key()
 
     assert ok is True
+    assert "OPENAI_API_KEY" in message
     assert "found" in message
 
 
-def test_check_openai_key_missing(monkeypatch):
+def test_check_api_key_anthropic(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
-    ok, message = check_openai_key()
+    ok, message = check_api_key()
+
+    assert ok is True
+    assert "ANTHROPIC_API_KEY" in message
+    assert "found" in message
+
+
+def test_check_api_key_openrouter(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    ok, message = check_api_key()
+
+    assert ok is True
+    assert "OPENROUTER_API_KEY" in message
+    assert "found" in message
+
+
+def test_check_api_key_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    ok, message = check_api_key()
 
     assert ok is False
-    assert "missing" in message
+    assert "No API key found" in message
 
 
 def test_plugin_manifests_exist(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- `check_openai_key()` renamed to `check_api_key()` and now accepts `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENROUTER_API_KEY`
- Users with Anthropic-only or OpenRouter-only setups no longer see a false FAIL

## Why
The doctor command advertises support for three providers but only validated the OpenAI key. A user who configured only `ANTHROPIC_API_KEY` would see `FAIL: No API key found` even though their environment is valid.

## Changes
- `src/webwright/run/doctor.py`: renamed function and extended check to three env vars
- `tests/unit/test_doctor.py`: updated existing tests and added Anthropic/OpenRouter cases

## Testing
```
pytest tests/unit/test_doctor.py -v
```

```
tests/unit/test_doctor.py::test_check_python PASSED
tests/unit/test_doctor.py::test_check_playwright PASSED
tests/unit/test_doctor.py::test_check_chromium PASSED
tests/unit/test_doctor.py::test_check_screenshot PASSED
tests/unit/test_doctor.py::test_check_api_key_openai PASSED
tests/unit/test_doctor.py::test_check_api_key_anthropic PASSED
tests/unit/test_doctor.py::test_check_api_key_openrouter PASSED
tests/unit/test_doctor.py::test_check_api_key_missing PASSED
tests/unit/test_doctor.py::test_plugin_manifests_exist PASSED
tests/unit/test_doctor.py::test_plugin_manifests_missing PASSED
tests/unit/test_doctor.py::test_screenshot_file_cleanup PASSED
11 passed in 0.15s
```